### PR TITLE
add SLList

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,4 @@
-[package]
-name = "open-data-structures-rs"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[workspace]
+members = [
+    "interface",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "interface",
+    "sllist",
 ]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "interface"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,0 +1,9 @@
+pub trait Queue<T> {
+    fn add(&mut self, x: T);
+    fn remove(&mut self) -> Option<T>;
+}
+
+pub trait Stack<T> {
+    fn push(&mut self, x: T);
+    fn pop(&mut self) -> Option<T>;
+}

--- a/sllist/Cargo.toml
+++ b/sllist/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sllist"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+interface = { path = "../interface" }

--- a/sllist/src/lib.rs
+++ b/sllist/src/lib.rs
@@ -1,0 +1,99 @@
+use interface::Stack;
+use std::rc::Rc;
+
+#[derive(Debug)]
+struct Node<T> {
+    x: T,
+    next: Option<Rc<Node<T>>>,
+}
+
+#[derive(Debug)]
+pub struct SLList<T> {
+    head: Option<Rc<Node<T>>>,
+    tail: Option<Rc<Node<T>>>,
+}
+
+impl<T> SLList<T> {
+    pub fn new() -> Self {
+        Self {
+            head: None,
+            tail: None,
+        }
+    }
+}
+
+impl<T> Stack<T> for SLList<T> {
+    // O(1) time
+    fn push(&mut self, x: T) {
+        let u = Node {
+            x,
+            next: self.head.take(),
+        };
+        let u = Rc::new(u);
+        // u (head) --> old_head
+        self.head = Some(Rc::clone(&u));
+        self.tail.get_or_insert(u);
+    }
+
+    // O(1) time
+    fn pop(&mut self) -> Option<T> {
+        let u = self.head.take()?;
+        match Rc::try_unwrap(u) {
+            Ok(mut u) => {
+                self.head = u.next.take();
+                debug_assert_eq!(self.head.is_some(), true);
+                Some(u.x)
+            }
+            Err(u) => {
+                // u = head = tail
+                debug_assert_eq!(Rc::strong_count(&u), 2);
+                let v = self.tail.take().unwrap();
+                debug_assert_eq!(Rc::ptr_eq(&u, &v), true);
+                drop(u);
+                let v = Rc::try_unwrap(v).ok().unwrap();
+                Some(v.x)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SLList;
+    use interface::Stack;
+
+    #[test]
+    fn test_pop() {
+        let mut stack = SLList::<()>::new();
+        let nil = stack.pop();
+        assert_eq!(nil, None);
+    }
+
+    #[test]
+    fn test_push_3_pop_4() {
+        let mut stack = SLList::<char>::new();
+        stack.push('a');
+        stack.push('b');
+        stack.push('c');
+        let c = stack.pop();
+        let b = stack.pop();
+        let a = stack.pop();
+        let nil = stack.pop();
+        assert_eq!(c, Some('c'));
+        assert_eq!(b, Some('b'));
+        assert_eq!(a, Some('a'));
+        assert_eq!(nil, None);
+    }
+
+    #[test]
+    fn test_push_2_pop_1_push_1_pop_1() {
+        let mut stack = SLList::<char>::new();
+        stack.push('a');
+        stack.push('b');
+        let b = stack.pop();
+        assert_eq!(b, Some('b'));
+        stack.push('x');
+        let x = stack.pop();
+        assert_eq!(x, Some('x'));
+    }
+}

--- a/sllist/src/lib.rs
+++ b/sllist/src/lib.rs
@@ -1,16 +1,16 @@
-use interface::Stack;
-use std::rc::Rc;
+use interface::{Queue, Stack};
+use std::{cell::RefCell, rc::Rc};
 
 #[derive(Debug)]
 struct Node<T> {
     x: T,
-    next: Option<Rc<Node<T>>>,
+    next: Option<Rc<RefCell<Node<T>>>>,
 }
 
 #[derive(Debug)]
 pub struct SLList<T> {
-    head: Option<Rc<Node<T>>>,
-    tail: Option<Rc<Node<T>>>,
+    head: Option<Rc<RefCell<Node<T>>>>,
+    tail: Option<Rc<RefCell<Node<T>>>>,
 }
 
 impl<T> SLList<T> {
@@ -29,7 +29,7 @@ impl<T> Stack<T> for SLList<T> {
             x,
             next: self.head.take(),
         };
-        let u = Rc::new(u);
+        let u = Rc::new(RefCell::new(u));
         // u (head) --> old_head
         self.head = Some(Rc::clone(&u));
         self.tail.get_or_insert(u);
@@ -39,7 +39,8 @@ impl<T> Stack<T> for SLList<T> {
     fn pop(&mut self) -> Option<T> {
         let u = self.head.take()?;
         match Rc::try_unwrap(u) {
-            Ok(mut u) => {
+            Ok(u) => {
+                let mut u = RefCell::into_inner(u);
                 self.head = u.next.take();
                 debug_assert_eq!(self.head.is_some(), true);
                 Some(u.x)
@@ -51,16 +52,39 @@ impl<T> Stack<T> for SLList<T> {
                 debug_assert_eq!(Rc::ptr_eq(&u, &v), true);
                 drop(u);
                 let v = Rc::try_unwrap(v).ok().unwrap();
+                let v = RefCell::into_inner(v);
                 Some(v.x)
             }
         }
     }
 }
 
+impl<T> Queue<T> for SLList<T> {
+    // O(1) time
+    fn add(&mut self, x: T) {
+        let u = Node { x, next: None };
+        let u = Rc::new(RefCell::new(u));
+        if let Some(t) = self.tail.take() {
+            // head = tail = t, or
+            // t and <second last node>.next point to the same allocation
+            RefCell::borrow_mut(&t).next = Some(Rc::clone(&u));
+            self.tail = Some(u);
+        } else {
+            // head = tail = None
+            self.head = Some(Rc::clone(&u));
+            self.tail = Some(u);
+        }
+    }
+
+    fn remove(&mut self) -> Option<T> {
+        self.pop()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::SLList;
-    use interface::Stack;
+    use interface::{Queue, Stack};
 
     #[test]
     fn test_pop() {
@@ -95,5 +119,40 @@ mod tests {
         stack.push('x');
         let x = stack.pop();
         assert_eq!(x, Some('x'));
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut queue = SLList::<()>::new();
+        let nil = queue.remove();
+        assert_eq!(nil, None);
+    }
+
+    #[test]
+    fn test_add_3_remove_4() {
+        let mut queue = SLList::<char>::new();
+        queue.add('a');
+        queue.add('b');
+        queue.add('c');
+        let a = queue.remove();
+        let b = queue.remove();
+        let c = queue.remove();
+        let nil = queue.remove();
+        assert_eq!(a, Some('a'));
+        assert_eq!(b, Some('b'));
+        assert_eq!(c, Some('c'));
+        assert_eq!(nil, None);
+    }
+
+    #[test]
+    fn test_add_2_remove_1_add_1_remove_1() {
+        let mut queue = SLList::<char>::new();
+        queue.add('a');
+        queue.add('b');
+        let a = queue.remove();
+        assert_eq!(a, Some('a'));
+        queue.add('x');
+        let b = queue.remove();
+        assert_eq!(b, Some('b'));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
chapter 3.1 `SLList`

単方向連結リスト `SLList` は

- 先頭ノードを指すポインタ (`head`)
- 末尾ノードを指すポインタ (`tail`)

を持つ。`push`, `pop`, `add`, `remove` のあとに適切に更新する。リストの要素数が 0 や 1 のときに注意する。

各ノードは

- 値 (`x`)
- 次のノードを指すポインタ (`next`)

を持つ。

# `Stack`
## `push(x)`

```mermaid
graph LR

a((a)) --> b(( )) -....-> t(( ))
head --> a
```

```mermaid
graph LR

u(( )) --> a((a)) --> b(( )) -....-> t(( ))
head --> u

style u fill:orange
```

リストの先頭に `x` のノードを、`next` がいままで先頭だったノードを指すようにつくる。

## `pop`

リストの先頭ノードを取り除いて返す。

# `Queue`
## `add(x)`

```mermaid
graph LR

a(( )) --> b(( )) -....-> s(( )) --> t((t))
tail --> t
```

```mermaid
graph LR

a(( )) --> b(( )) -....-> s(( )) --> t((t)) --> u(( ))
tail --> u

style u fill:orange
```

リストの末尾に `x` のノード `u` をつくる。

いままで末尾だったノードの `next` が `u` を指すように**書き換える**。

このために `Rc<RefCell<T>>` パターンが必要になる。末尾のノードを指すポインタは

- リストが空の場合: 0 個
- リストが 1 要素のみからなる場合: `head` と `tail` の 2 個
- それ以外: `tail` と「いままで末尾だったノードの `next`」の 2 個

## `remove`

`stack` の `pop` と同じ。