### PR TITLE
Skip list sorted set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "interface",
     "sllist",
     "dllist",
+    "skiplist-sset",
 ]

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -15,3 +15,11 @@ pub trait List<T> {
     fn add(&mut self, i: usize, x: T);
     fn remove(&mut self, i: usize) -> T;
 }
+
+pub trait SSet<T> {
+    fn size(&self) -> usize;
+    fn add(&mut self, x: T) -> bool;
+    fn remove(&mut self, x: &T) -> bool;
+    // lower bound
+    fn find(&self, x: &T) -> Option<&T>;
+}

--- a/skiplist-sset/Cargo.toml
+++ b/skiplist-sset/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "skiplist-sset"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand = { version = "0.8.5", features = ["small_rng"] }
+interface = { path = "../interface" }

--- a/skiplist-sset/examples/bench.rs
+++ b/skiplist-sset/examples/bench.rs
@@ -1,0 +1,44 @@
+use std::collections::BTreeSet;
+use std::time::Instant;
+
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+use interface::SSet;
+use skiplist_sset::SkipListSSet;
+
+fn main() {
+    let mut rng = SmallRng::seed_from_u64(122333);
+    let n = 200_000;
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    for _ in 0..n {
+        a.push(rng.gen_range(0..n));
+        b.push(rng.gen_range(0..n));
+    }
+
+    let mut set = BTreeSet::new();
+    let now = Instant::now();
+    for &a in &a {
+        set.insert(a);
+    }
+    for b in &b {
+        set.remove(b);
+    }
+    println!(
+        "std::collections::BTreeSet {} ms",
+        now.elapsed().as_millis()
+    );
+
+    let mut set = SkipListSSet::new();
+    let now = Instant::now();
+    for &a in &a {
+        set.add(a);
+    }
+    for b in &b {
+        set.remove(b);
+    }
+    println!("SkipListSSet {} ms", now.elapsed().as_millis());
+
+    // std::collections::BTreeSet 33 ms
+    // SkipListSSet 5853 ms
+}

--- a/skiplist-sset/examples/bench.rs
+++ b/skiplist-sset/examples/bench.rs
@@ -39,6 +39,6 @@ fn main() {
     }
     println!("SkipListSSet {} ms", now.elapsed().as_millis());
 
-    // std::collections::BTreeSet 33 ms
-    // SkipListSSet 5853 ms
+    // std::collections::BTreeSet 57 ms
+    // SkipListSSet 664 ms
 }

--- a/skiplist-sset/examples/chars.rs
+++ b/skiplist-sset/examples/chars.rs
@@ -1,0 +1,41 @@
+use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
+
+use interface::SSet;
+use skiplist_sset::SkipListSSet;
+
+fn main() {
+    let mut rng = SmallRng::from_entropy();
+    let mut chars: Vec<char> = "abcde".chars().collect();
+    chars.shuffle(&mut rng);
+
+    let mut set = SkipListSSet::new();
+    for ch in chars {
+        set.add(ch);
+    }
+
+    println!("{:?}", set);
+
+    set.remove(&'c');
+    println!("{:?}", set);
+
+    set.remove(&'d');
+    println!("{:?}", set);
+
+    // ~	#######
+    // 'a'	#
+    // 'b'	#####
+    // 'c'	######
+    // 'd'	#######
+    // 'e'	###
+    //
+    // ~	#######
+    // 'a'	#
+    // 'b'	#####
+    // 'd'	#######
+    // 'e'	###
+    //
+    // ~	#####
+    // 'a'	#
+    // 'b'	#####
+    // 'e'	###
+}

--- a/skiplist-sset/src/lib.rs
+++ b/skiplist-sset/src/lib.rs
@@ -58,7 +58,13 @@ where
     fn pick_height() -> usize {
         // 毎回 rng を生成しているためパフォーマンスが悪そう
         let mut small_rng = SmallRng::from_entropy();
-        small_rng.gen_range(0..32)
+        // 返り値 : 確率
+        // 0 : 1/2
+        // 1 : 1/4
+        // 2 : 1/8
+        // 3 : 1/16
+        // ...
+        small_rng.gen_range(0..u32::MAX).trailing_ones() as usize
     }
 
     fn find_pred_node(&self, x: &T) -> *mut Node<T> {

--- a/skiplist-sset/src/lib.rs
+++ b/skiplist-sset/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{alloc, ptr};
+use std::{
+    alloc,
+    fmt::{self, Formatter},
+    ptr,
+};
 
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
@@ -177,6 +181,31 @@ where
             debug_assert!(x.is_some());
             x
         }
+    }
+}
+
+impl<T> fmt::Debug for SkipListSSet<T>
+where
+    T: PartialOrd + fmt::Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut u = self.sentinel;
+        let h = unsafe { &*u }
+            .next
+            .iter()
+            .take_while(|v| !v.is_null())
+            .count();
+        write!(f, "~\t{}", "#".repeat(h))?;
+        writeln!(f)?;
+        u = unsafe { &*u }.next[0];
+        while !u.is_null() {
+            let h = unsafe { &*u }.height();
+            let x = unsafe { &*u }.x.as_ref().unwrap();
+            write!(f, "{:?}\t{}", x, "#".repeat(h))?;
+            writeln!(f)?;
+            u = unsafe { &*u }.next[0];
+        }
+        Ok(())
     }
 }
 

--- a/skiplist-sset/src/lib.rs
+++ b/skiplist-sset/src/lib.rs
@@ -1,0 +1,230 @@
+use std::{alloc, ptr};
+
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+use interface::SSet;
+
+struct Node<T>
+where
+    T: PartialOrd,
+{
+    x: Option<T>,
+    next: Vec<*mut Node<T>>,
+}
+
+impl<T> Node<T>
+where
+    T: PartialOrd,
+{
+    fn new(x: Option<T>, height: usize) -> Self {
+        Self {
+            x,
+            next: vec![ptr::null_mut(); height + 1],
+        }
+    }
+
+    fn height(&self) -> usize {
+        self.next.len()
+    }
+}
+
+pub struct SkipListSSet<T>
+where
+    T: PartialOrd,
+{
+    sentinel: *mut Node<T>,
+    height: usize, // 「i <= height iff. sentinel.next[i] が non null」となるようにする
+    n: usize,
+}
+
+impl<T> SkipListSSet<T>
+where
+    T: PartialOrd,
+{
+    pub fn new() -> Self {
+        let sentinel = Node::new(None, 32);
+        let sentinel = Box::into_raw(Box::new(sentinel));
+        Self {
+            sentinel,
+            height: 0,
+            n: 0,
+        }
+    }
+
+    fn pick_height() -> usize {
+        let mut small_rng = SmallRng::from_entropy();
+        small_rng.gen_range(0..32)
+    }
+
+    fn find_pred_node(&self, x: &T) -> *mut Node<T> {
+        let mut u = self.sentinel;
+        for r in (0..=self.height).rev() {
+            loop {
+                let next = unsafe { &*u }.next[r];
+                if next.is_null() {
+                    break;
+                }
+                let y = unsafe { &*next }.x.as_ref().unwrap();
+                if y.lt(x) {
+                    u = next;
+                } else {
+                    break;
+                }
+            }
+        }
+        u
+    }
+}
+
+impl<T> SSet<T> for SkipListSSet<T>
+where
+    T: PartialOrd,
+{
+    fn size(&self) -> usize {
+        self.n
+    }
+
+    fn add(&mut self, x: T) -> bool {
+        let mut u = self.sentinel;
+        let h = Self::pick_height(); // 新しく追加するノードの高さ
+        let mut stack = Vec::new(); // stack ?
+        for r in (0..=self.height.max(h)).rev() {
+            let exist = loop {
+                let next = unsafe { &*u }.next[r];
+                if next.is_null() {
+                    // x が skip list 内のどの要素よりも大きい
+                    break false;
+                }
+                let y = unsafe { &*next }.x.as_ref().unwrap();
+                if x.gt(y) {
+                    u = next;
+                } else {
+                    break x.eq(y);
+                }
+            };
+            if exist {
+                // x と等しい要素があった場合ノードを追加しない
+                return false;
+            }
+            stack.push(u);
+        }
+        stack.reverse();
+
+        let w = Box::into_raw(Box::new(Node::new(Some(x), h)));
+        for i in 0..=h {
+            unsafe {
+                (*w).next[i] = (*stack[i]).next[i];
+            }
+            unsafe {
+                (*stack[i]).next[i] = w;
+            }
+        }
+
+        self.height = self.height.max(h);
+        self.n += 1;
+
+        true
+    }
+
+    fn remove(&mut self, x: &T) -> bool {
+        let mut removed = false;
+        let mut del = ptr::null_mut();
+        let mut u = self.sentinel;
+        for r in (0..=self.height).rev() {
+            let delete_next_node = loop {
+                let next = unsafe { &*u }.next[r];
+                if next.is_null() {
+                    break false;
+                }
+                let y = unsafe { &*next }.x.as_ref().unwrap();
+                if x.gt(y) {
+                    u = next;
+                } else {
+                    break x.eq(y);
+                }
+            };
+            if delete_next_node {
+                removed = true;
+                del = unsafe { &*u }.next[r];
+                unsafe { (*u).next[r] = (*(*u).next[r]).next[r] };
+                if u == self.sentinel && unsafe { &*u }.next[r].is_null() {
+                    if self.height == 0 {
+                        // x を消すと要素数が 0 になるケースでここに来るはず
+                        debug_assert_eq!(r, 0);
+                        debug_assert_eq!(self.n, 1);
+                    } else {
+                        self.height -= 1;
+                    }
+                }
+            }
+        }
+        if removed {
+            debug_assert!(!del.is_null());
+            unsafe { ptr::drop_in_place(del) };
+            unsafe { alloc::dealloc(del as *mut u8, alloc::Layout::new::<Node<T>>()) };
+            self.n -= 1;
+        }
+        removed
+    }
+
+    fn find(&self, x: &T) -> Option<&T> {
+        let u = self.find_pred_node(x);
+        let next = unsafe { &*u }.next[0];
+        if next.is_null() {
+            None
+        } else {
+            let x = unsafe { &*next }.x.as_ref();
+            debug_assert!(x.is_some());
+            x
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SkipListSSet;
+    use interface::SSet;
+
+    #[test]
+    fn test_add_twice() {
+        let mut set = SkipListSSet::new();
+        let added = set.add('a');
+        assert!(added);
+        assert_eq!(set.size(), 1);
+        let added = set.add('a');
+        assert!(!added);
+        assert_eq!(set.size(), 1);
+    }
+
+    #[test]
+    fn test_remove_twice() {
+        let mut set = SkipListSSet::new();
+        set.add('a');
+        let removed = set.remove(&'a');
+        assert!(removed);
+        let removed = set.remove(&'a');
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_find() {
+        let mut set = SkipListSSet::new();
+        assert_eq!(set.find(&'a'), None);
+        set.add('a');
+        set.add('p');
+        set.add('b');
+        set.add('q');
+        set.add('j');
+        set.add('i');
+        // a b i j p q
+        assert_eq!(set.find(&'a'), Some(&'a'));
+        assert_eq!(set.find(&'b'), Some(&'b'));
+        assert_eq!(set.find(&'c'), Some(&'i'));
+        assert_eq!(set.find(&'i'), Some(&'i'));
+        assert_eq!(set.find(&'j'), Some(&'j'));
+        assert_eq!(set.find(&'k'), Some(&'p'));
+        assert_eq!(set.find(&'p'), Some(&'p'));
+        assert_eq!(set.find(&'q'), Some(&'q'));
+        assert_eq!(set.find(&'r'), None);
+    }
+}

--- a/skiplist-sset/src/lib.rs
+++ b/skiplist-sset/src/lib.rs
@@ -92,7 +92,7 @@ where
     fn add(&mut self, x: T) -> bool {
         let mut u = self.sentinel;
         let h = Self::pick_height(); // 新しく追加するノードの高さ
-        let mut stack = Vec::new(); // stack ?
+        let mut stack = Vec::new(); // 固定長の配列 self.buf: [*mut Node<T>; 32] を使い回すほうが速くなりそう
         for r in (0..=self.height.max(h)).rev() {
             let exist = loop {
                 let next = unsafe { &*u }.next[r];

--- a/skiplist-sset/src/lib.rs
+++ b/skiplist-sset/src/lib.rs
@@ -56,6 +56,7 @@ where
     }
 
     fn pick_height() -> usize {
+        // 毎回 rng を生成しているためパフォーマンスが悪そう
         let mut small_rng = SmallRng::from_entropy();
         small_rng.gen_range(0..32)
     }
@@ -135,6 +136,7 @@ where
         let mut del = ptr::null_mut();
         let mut u = self.sentinel;
         for r in (0..=self.height).rev() {
+            // add のときとまったく同じ
             let delete_next_node = loop {
                 let next = unsafe { &*u }.next[r];
                 if next.is_null() {


### PR DESCRIPTION
chapter 4.2 SkiplistSSet

スキップリストは複数の単方向連結リストによりノードを辿れるようにする。各ノードはポインタで、保持するデータは次のもの。

- 要素の実体 `x`
- ノード (自分) の「高さ」 `h`
- リスト L_0, L_1, ..., L_h 内の「次」のノード `next[0]`, `next[1]`, ..., `next[h]`

「高さ」は要素の追加時に**ランダムに**決める。具体的には、1/2 の確率で 0 を, 1/4 の確率で 1 を, 1/8 の確率で 2 を, 1/16 の確率で 3 を, ... といった要領で高さを割り当てる。

このようにすると、要素数を n として、

- 最も「下」の連結リスト L_0 は n + 1 個のノード
  - "+1" はダミーノード
- L_1 は約 n/2 個のノード
- L_2 は約 n/4 個のノード
- ...

になる。つまり、スキップリストでは n 個の要素を管理するために expected O(n*2) 個のノードを持つ。

![skiplist_fig_4_1](https://user-images.githubusercontent.com/23146842/157655257-80d5cc80-bca8-48d9-9e8a-8b199fbf6197.png)

図を『[みんなのデータ構造](https://sites.google.com/view/open-data-structures-ja/home)』から引用。上の図でノード 2 は高さ 3 であり

- `next[3]` = 4
- `next[2]` = 3
- `next[1]` = 3
- `next[0]` = 3

となる。

# `SSet.add`

skip list を使って sorted set の `add` を実装するには、適切な位置 (要素が昇順を保つような位置) にノードを挿入する必要がある。

これは次のようにできる。再び『みんなのデータ構造』から図を引用。`add` が終わったあとの図であることに注意する。

![skiplist_fig_4_3](https://user-images.githubusercontent.com/23146842/157660256-90e19f59-204f-4fd0-9e5b-a7ed2bd38302.png)

set に 1, 2, 3, 4, 5, 6 が入っている状態から 3.5 を追加する例を考える。ノードの `next[]` を見ながら「下」に進むか「右」に進むかを決める。

- `sentinel.next[5]` は 4 を指している。3.5 < 4 なので下に進む。
- `sentinel.next[4]` は 4 を指している。3.5 < 4 なので下に進む。
- `sentinel.next[3]` は 2 を指している。3.5 > 2 なので右に進む。
- `node2.next[3]` は 4 を指している。3.5 < 4 なので下に進む。
- `node2.next[2]` は 3 を指している。3.5 > 3 なので右に進む。
- `node3.next[2]` は 4 を指している。3.5 < 4 なので下に進む。
- `node3.next[1]` は 4 を指している。3.5 < 4 なので下に進む。
- 高さ 0 まで来たので `node3.next[0]` に 3.5 をセットし、他のリンクも適当に更新する。赤矢印の箇所。

# `SSet.remove`, `SSet.find`

`SSet.remove`, `SSet.find` は省略。:bow:

- `remove` は `add` と同じ程度の複雑さ
  - 各リストの更新があるため
- `find` は簡単