### PR TITLE
Binary Trie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "skiplist-list",
     "treap",
     "scapegoat-tree",
+    "binary-trie",
 ]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -14,3 +14,4 @@ skiplist-list = { path = "../skiplist-list" }
 skiplist-sset = { path = "../skiplist-sset" }
 treap = { path = "../treap" }
 scapegoat-tree = { path = "../scapegoat-tree" }
+binary-trie = { path = "../binary-trie" }

--- a/benchmark/src/bin/sset.rs
+++ b/benchmark/src/bin/sset.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
+use binary_trie::{BinaryTrie, IntValue};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 use interface::SSet;
@@ -40,7 +41,7 @@ fn add_remove<T>(mut set: impl SSet<T>, a: Vec<T>, b: Vec<T>) -> Duration {
 
 fn run<T>(label: &str, a: Vec<T>, b: Vec<T>)
 where
-    T: Clone + Ord,
+    T: Clone + Ord + IntValue,
 {
     let elapsed = add_remove(MyBTreeSet(BTreeSet::new()), a.clone(), b.clone());
     println!(
@@ -57,30 +58,38 @@ where
 
     let elapsed = add_remove(ScapegoatTree::new(), a.clone(), b.clone());
     println!("[{}] ScapegoatTree {} ms", label, elapsed.as_millis());
+
+    let elapsed = add_remove(BinaryTrie::new(), a.clone(), b.clone());
+    println!("[{}] BinaryTrie {} ms", label, elapsed.as_millis());
 }
 
 fn main() {
     let mut rng = SmallRng::seed_from_u64(1223334);
 
     let n = 200_000;
+    let m = 200_000_u32;
 
     let mut a = vec![0; n];
     let mut b = vec![0; n];
     for i in 0..n {
-        a[i] = rng.gen_range(0..n);
-        b[i] = rng.gen_range(0..n);
+        a[i] = rng.gen_range(0..m);
+        b[i] = rng.gen_range(0..m);
     }
 
     run("random", a, b);
-    run("sorted", (0..n).collect(), (0..n).collect());
+    run("sorted", (0..m).collect(), (0..m).collect());
 
-    // [random] std::collections::BTreeSet 45 ms
-    // [random] SkipListSSet 472 ms
-    // [random] Treap 191 ms
-    // [random] ScapegoatTree 176 ms
+    // メモリ確保・解放の時間が多くを占めている気がする……
 
-    // [sorted] std::collections::BTreeSet 34 ms
-    // [sorted] SkipListSSet 301 ms
-    // [sorted] Treap 51 ms
-    // [sorted] ScapegoatTree 608 ms
+    // [random] std::collections::BTreeSet 60 ms
+    // [random] SkipListSSet 1908 ms
+    // [random] Treap 309 ms
+    // [random] ScapegoatTree 443 ms
+    // [random] BinaryTrie 508 ms
+
+    // [sorted] std::collections::BTreeSet 78 ms
+    // [sorted] SkipListSSet 1945 ms
+    // [sorted] Treap 302 ms
+    // [sorted] ScapegoatTree 8309 ms
+    // [sorted] BinaryTrie 700 ms
 }

--- a/binary-trie/Cargo.toml
+++ b/binary-trie/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "binary-trie"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+interface = { path = "../interface" }
+
+[dev-dependencies]
+rand = { version = "0.8.5", features = ["small_rng"] }

--- a/binary-trie/src/lib.rs
+++ b/binary-trie/src/lib.rs
@@ -1,0 +1,303 @@
+use std::{alloc, ptr};
+
+use interface::SSet;
+
+struct Node<T> {
+    // 葉 ⇒ x = Some(.), child = [NULL, NULL]
+    // 葉以外 ⇒ x = None, prev = next = NULL
+    x: Option<T>,
+    child: [*mut Node<T>; 2], // left, right
+    parent: *mut Node<T>,
+    prev: *mut Node<T>,
+    next: *mut Node<T>,
+    jump: *mut Node<T>,
+}
+
+pub struct BinaryTrie<T> {
+    n: usize,
+    root: *mut Node<T>,
+    dummy: *mut Node<T>,
+}
+
+pub trait IntValue {
+    fn int_value(&self) -> u64;
+}
+
+macro_rules! impl_int_value {
+     ($($t:ty),+) => {
+         $(
+            impl IntValue for $t {
+                fn int_value(&self) -> u64 {
+                    u64::from(*self)
+                }
+            }
+         )+
+     };
+}
+
+impl_int_value!(bool, char, u8, u16, u32, u64);
+
+impl<T> BinaryTrie<T> {
+    pub fn new() -> Self {
+        let dummy = Box::into_raw(Box::new(Node {
+            x: None,
+            child: [ptr::null_mut(), ptr::null_mut()],
+            parent: ptr::null_mut(),
+            prev: ptr::null_mut(),
+            next: ptr::null_mut(),
+            jump: ptr::null_mut(),
+        }));
+        // prev, next だけ使う
+        unsafe { (*dummy).prev = dummy };
+        unsafe { (*dummy).next = dummy };
+        Self {
+            n: 0,
+            root: Box::into_raw(Box::new(Node {
+                x: None,
+                child: [ptr::null_mut(), ptr::null_mut()],
+                parent: ptr::null_mut(),
+                prev: ptr::null_mut(),
+                next: ptr::null_mut(),
+                jump: dummy,
+            })),
+            dummy,
+        }
+    }
+}
+
+impl<T> SSet<T> for BinaryTrie<T>
+where
+    T: IntValue,
+{
+    fn size(&self) -> usize {
+        self.n
+    }
+
+    fn add(&mut self, x: T) -> bool {
+        let w = u64::BITS;
+        let ix = x.int_value();
+        let mut u = self.root;
+        for i in 0..w {
+            let b = (ix >> (w - i - 1) & 1) as usize;
+            let child = unsafe { &*u }.child[b];
+            if child != ptr::null_mut() {
+                u = child;
+            } else {
+                // pred = (x より小さい最大の要素)
+                let pred = if b == 1 {
+                    // 1: right
+                    unsafe { (*u).jump }
+                } else {
+                    // 0: left
+                    debug_assert_eq!(b, 0);
+                    // u.jump は x より大きい最小の要素を指すので prev でひとつ戻す
+                    unsafe { (*(*u).jump).prev }
+                };
+
+                // ix への経路をつくる
+                for j in i..w {
+                    let b = (ix >> (w - j - 1) & 1) as usize;
+                    let child = Box::into_raw(Box::new(Node {
+                        x: None,
+                        child: [ptr::null_mut(), ptr::null_mut()],
+                        parent: u,
+                        prev: ptr::null_mut(),
+                        next: ptr::null_mut(),
+                        jump: ptr::null_mut(),
+                    }));
+                    unsafe { (*u).child[b] = child };
+                    u = child;
+                }
+
+                // 深さ w のノードが葉なので x を保持
+                unsafe { (*u).x = Some(x) };
+
+                // u を葉の連結リストに入れる
+                unsafe { (*u).prev = pred };
+                unsafe { (*u).next = (*pred).next };
+                unsafe { (*(*u).prev).next = u };
+                unsafe { (*(*u).next).prev = u };
+
+                let mut v = unsafe { &*u }.parent;
+                while v != ptr::null_mut() {
+                    let left = unsafe { &*v }.child[0];
+                    let right = unsafe { &*v }.child[1];
+                    let jump = unsafe { &*v }.jump;
+                    let left_jump = left == ptr::null_mut() // 左の子がいない
+                        && (jump == ptr::null_mut() || jump == self.dummy // jump ポインタがない
+                            // ix が v の部分木内で最小
+                            || unsafe { &*jump }.x.as_ref().unwrap().int_value() > ix);
+                    let right_jump = right == ptr::null_mut()
+                        && (jump == ptr::null_mut() || jump == self.dummy
+                            // ix が v の部分木内で最大
+                            || unsafe { &*jump }.x.as_ref().unwrap().int_value() < ix);
+
+                    if left != ptr::null_mut() && right != ptr::null_mut() {
+                        unsafe { (*v).jump = ptr::null_mut() };
+                    } else if left_jump || right_jump {
+                        unsafe { (*v).jump = u };
+                    }
+
+                    v = unsafe { &*v }.parent;
+                }
+
+                self.n += 1;
+                return true;
+            }
+        }
+
+        // 葉まで辿りついたのですでに x が BinaryTrie に含まれていた
+        false
+    }
+
+    fn remove(&mut self, x: &T) -> bool {
+        let w = u64::BITS;
+        let ix = x.int_value();
+        let mut u = self.root;
+
+        for i in 0..w {
+            let b = (ix >> (w - i - 1) & 1) as usize;
+            let child = unsafe { &*u }.child[b];
+            if child == ptr::null_mut() {
+                return false;
+            }
+            u = child;
+        }
+
+        debug_assert!(unsafe { &*u }.x.is_some());
+        // debug_assert_eq!(unsafe {&*u}.x.as_ref(), Some(x));
+
+        // u を葉の連結リストから除く
+        unsafe { (*(*u).prev).next = (*u).next };
+        unsafe { (*(*u).next).prev = (*u).prev };
+
+        let mut v = u;
+        for i in (0..w).rev() {
+            v = unsafe { &*v }.parent;
+            let b = (ix >> (w - i - 1) & 1) as usize;
+            unsafe { ptr::drop_in_place((*v).child[b]) };
+            unsafe { alloc::dealloc((*v).child[b] as *mut u8, alloc::Layout::new::<Node<T>>()) };
+            unsafe { (*v).child[b] = ptr::null_mut() };
+
+            // 左 or 右の子があるので v は消さない
+            if unsafe { &*v }.child[1 - b] != ptr::null_mut() {
+                let prev = unsafe { &*u }.prev;
+                let next = unsafe { &*u }.next;
+                debug_assert_eq!(unsafe { &*v }.jump, ptr::null_mut());
+                unsafe { (*v).jump = if b == 0 { next } else { prev } };
+                v = unsafe { &*v }.parent;
+                for j in (0..i).rev() {
+                    let b = (ix >> (w - j - 1) & 1) as usize;
+                    if unsafe { &*v }.jump == u {
+                        unsafe { (*v).jump = if b == 0 { next } else { prev } };
+                    }
+                    v = unsafe { &*v }.parent;
+                }
+                debug_assert_eq!(v, ptr::null_mut());
+                break;
+            }
+        }
+
+        true
+    }
+
+    fn find(&self, x: &T) -> Option<&T> {
+        if self.n == 0 {
+            return None;
+        }
+
+        let w = u64::BITS;
+        let ix = x.int_value();
+        let mut u = self.root;
+        for i in 0..w {
+            let b = (ix >> (w - i - 1) & 1) as usize;
+            let child = unsafe { &*u }.child[b];
+            if child == ptr::null_mut() {
+                break;
+            }
+            u = child;
+        }
+        let left = unsafe { &*u }.child[0];
+        let right = unsafe { &*u }.child[1];
+        if left == ptr::null_mut() && right == ptr::null_mut() {
+            // 葉
+            let x = unsafe { &*u }.x.as_ref();
+            debug_assert!(x.is_some());
+            x
+        } else {
+            let v = unsafe { &*u }.jump;
+            if left == ptr::null_mut() {
+                let x = unsafe { &*v }.x.as_ref();
+                if v == self.dummy {
+                    debug_assert!(x.is_none());
+                } else {
+                    debug_assert!(x.is_some());
+                }
+                x
+            } else if right == ptr::null_mut() {
+                let w = unsafe { &*v }.next;
+                let x = unsafe { &*w }.x.as_ref();
+                if w == self.dummy {
+                    debug_assert!(x.is_none());
+                } else {
+                    debug_assert!(x.is_some());
+                }
+                x
+            } else {
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BinaryTrie;
+    use interface::SSet;
+    use rand::{rngs::SmallRng, Rng, SeedableRng};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn test_find() {
+        let mut binary_trie = BinaryTrie::<u8>::new();
+        assert_eq!(binary_trie.find(&0), None);
+        binary_trie.add(0);
+        binary_trie.add(10);
+        binary_trie.add(100);
+        assert_eq!(binary_trie.find(&0), Some(&0));
+        assert_eq!(binary_trie.find(&1), Some(&10));
+        assert_eq!(binary_trie.find(&10), Some(&10));
+        assert_eq!(binary_trie.find(&11), Some(&100));
+        assert_eq!(binary_trie.find(&101), None);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut binary_trie = BinaryTrie::<u8>::new();
+        binary_trie.add(42);
+        let removed = binary_trie.remove(&42);
+        assert!(removed);
+        let removed = binary_trie.remove(&42);
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_random() {
+        let mut rng = SmallRng::seed_from_u64(0);
+        let mut binary_trie = BinaryTrie::<u32>::new();
+        let mut btree_set = BTreeSet::new();
+        let n = 1000;
+        for _ in 0..n {
+            let x = rng.gen_range(0..n);
+            assert_eq!(binary_trie.add(x), btree_set.insert(x));
+        }
+        for _ in 0..n {
+            let x = rng.gen_range(0..n);
+            assert_eq!(binary_trie.find(&x), btree_set.range(&x..).next());
+        }
+        for _ in 0..n {
+            let x = rng.gen_range(0..n);
+            assert_eq!(binary_trie.remove(&x), btree_set.remove(&x));
+        }
+    }
+}


### PR DESCRIPTION
chapter 13.1

BinaryTrie は 0 以上 2^w 未満の整数のみを扱う二分木。

葉は深さ w にあり、双方向連結リストでつなぐ。

葉以外のノード u には以下の `jump` ポインタを持たせる。このポインタは検索 `find(x)` の高速化に寄与する。

- 左の子がない場合:  
  u を根とする部分木内で最小の葉 (最も左の葉) を指すポインタ
- 右の子がない場合:  
  u を根とする部分木内で最大の葉 (最も右の葉) を指すポインタ

# `add(x)`

根から始めて、深さ i = 0, 1, ..., w - 1 の順に、  
x の上から i ビット目が 0 なら左、1 なら右に (ノードがなければ作って) 進む。

# `find(x)`

まず x の二進表記から、木を辿ると

- x 以上で最小の葉
- x 以下で最大の葉

がわかる。葉同士は双方向連結リストでつながっているため、その後はたかだか 1 回リストを辿ればよい。